### PR TITLE
update typo in exposures schema

### DIFF
--- a/lib/film_flow/settings/exposure.ex
+++ b/lib/film_flow/settings/exposure.ex
@@ -13,7 +13,7 @@ defmodule FilmFlow.Settings.Exposure do
     field :shutter_speed, :id
     field :camera, :id
     field :zone, :id
-    field :lense, :id
+    field :lens, :id
     field :filter, :id
     field :tripod, :id
     field :holder, :id


### PR DESCRIPTION
lens was mistakenly spelled as "lense"