### PR TITLE
add exposure guide page

### DIFF
--- a/lib/film_flow_web/components/layouts/app.html.heex
+++ b/lib/film_flow_web/components/layouts/app.html.heex
@@ -25,6 +25,7 @@
           <a href="/locations" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Locations</a>
           <a href="/exposure_records" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Exposure Records</a>
           <a href="/exposures" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Exposures</a>
+          <a href="/exposure-guide" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Exposure Guide</a>
           <a href="/filters" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Filters</a>
           <a href="/holders" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Holders</a>
           <a href="/film_backs" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Film Backs</a>

--- a/lib/film_flow_web/live/exposure_guide_live/index.ex
+++ b/lib/film_flow_web/live/exposure_guide_live/index.ex
@@ -1,0 +1,176 @@
+defmodule FilmFlowWeb.ExposureGuideLive.Index do
+  use FilmFlowWeb, :live_view
+
+  @moduledoc """
+  LiveView for the exposure guide, including exposure values, zone system, and shooting conditions.
+  """
+
+  @exposure_values [
+    %{ev: -6, condition: "Rural area lit by starlight."},
+    %{ev: -5, condition: "Night, rural lit by crescent moon."},
+    %{ev: -4, condition: "Night, rural, lit by half moon."},
+    %{ev: -3, condition: "Night, rural, lit by full moon."},
+    %{ev: -2, condition: "Night, snow or sand under full moon."},
+    %{ev: -1, condition: "Night, away from city lights."},
+    %{ev: 0, condition: "Dim interior, artificial light."},
+    %{ev: 1, condition: "Distant view of city skyline at night."},
+    %{ev: 2, condition: "Lit city skyline at night"},
+    %{ev: 3, condition: "Candlelight. Lit buildings at distance."},
+    %{ev: 4, condition: "Holiday lighting. Candlelit close-ups."},
+    %{ev: 5, condition: "Floodlit buildings and monuments."},
+    %{ev: 6, condition: "Home interiors. Auditoriums."},
+    %{ev: 7, condition: "Lit streets and shops at night. Fairs."},
+    %{ev: 8, condition: "Sports/stage events. Offices. Campfires."},
+    %{ev: 9, condition: "Pre-dusk or dawn. Neon. Spotlights."},
+    %{ev: 10, condition: "Landscape at dusk or dawn."},
+    %{ev: 11, condition: "Open shade. Sunsets."},
+    %{ev: 12, condition: "Heavy overcast."},
+    %{ev: 13, condition: "Overcast. No shadows."},
+    %{ev: 14, condition: "Hazy sunlight. Slight overcast."},
+    %{ev: 15, condition: "Bright or hazy sun (Sunny 16 rule)."},
+    %{ev: 16, condition: "Bright daylight on sand or snow."},
+    %{ev: "17-21", condition: "Unnaturally bright. Man-made lighting."},
+    %{ev: "22-23", condition: "Extremely bright. Rare, unnatural."}
+  ]
+
+  @zone_system [
+    %{zone: "0", description: "Pure black."},
+    %{zone: "I", description: "Near black, slight tonality but no texture."},
+    %{zone: "II", description: "Dark black, slight detail/texture in darkest areas."},
+    %{zone: "III", description: "Very dark materials and low values with adequate textures"},
+    %{zone: "IV", description: "Dark foliage, dark stone, or landscape shadows."},
+    %{zone: "V", description: "Middle gray, clear north sky, dark skin, weathered wood"},
+    %{zone: "VI", description: "Caucasian skin, light stone, snow shadows in sunlit landscapes."},
+    %{zone: "VII", description: "Light skin tone, shadows in snow with acute side lighting."},
+    %{zone: "VIII", description: "Lightest tone with texture, textured snow."},
+    %{zone: "IX", description: "Slight tone without texture, glaring snow."},
+    %{zone: "X", description: "Pure white, light sources and specular reflections."}
+  ]
+
+  @symbol_key [
+    %{symbol: "☀️", meaning: "Sunny"},
+    %{symbol: "⛅", meaning: "Partly Cloudy"},
+    %{symbol: "☁️", meaning: "Cloudy"},
+    %{symbol: "🌙", meaning: "Night"},
+    %{symbol: "🌅", meaning: "Sunrise/Sunset"},
+    %{symbol: "🌧️", meaning: "Rain"},
+    %{symbol: "❄️", meaning: "Snow"},
+    %{symbol: "🌫️", meaning: "Fog"},
+    %{symbol: "🌲", meaning: "Forest"},
+    %{symbol: "🏙️", meaning: "Urban"},
+    %{symbol: "🏖️", meaning: "Beach"},
+    %{symbol: "🏔️", meaning: "Mountain"},
+    %{symbol: "🌊", meaning: "Water"},
+    %{symbol: "🏛️", meaning: "Architecture"},
+    %{symbol: "🎭", meaning: "Portrait"}
+  ]
+
+  @compile {:inline, exposure_values: 0}
+  @compile {:inline, zone_system: 0}
+  @compile {:inline, symbol_key: 0}
+
+  def exposure_values, do: @exposure_values
+  def zone_system, do: @zone_system
+  def symbol_key, do: @symbol_key
+
+  def mount(_params, _session, socket) do
+    films = FilmFlow.Settings.list_film()
+
+    socket =
+      assign(socket,
+        exposure_values: exposure_values(),
+        zone_system: zone_system(),
+        symbol_key: symbol_key(),
+        iso: 100,
+        selected_ev: 15,
+        selected_zone: "V",
+        used_symbols: [],
+        aperture: "f/16",
+        shutter_speed: "1/100",
+        notes: "",
+        films: films
+      )
+
+    {:ok, socket}
+  end
+
+  def handle_event("select_ev", %{"ev" => ev_string}, socket) do
+    ev =
+      case Integer.parse(ev_string) do
+        {ev, _} -> ev
+        :error -> ev_string
+      end
+
+    {aperture, shutter_speed} = calculate_exposure(ev, socket.assigns.iso)
+
+    {:noreply, assign(socket, selected_ev: ev, aperture: aperture, shutter_speed: shutter_speed)}
+  end
+
+  def handle_event("select_zone", %{"zone" => zone}, socket) do
+    {:noreply, assign(socket, selected_zone: zone)}
+  end
+
+  def handle_event("update_iso", %{"value" => iso_string}, socket) do
+    iso = String.to_integer(iso_string)
+    {aperture, shutter_speed} = calculate_exposure(socket.assigns.selected_ev, iso)
+
+    {:noreply, assign(socket, iso: iso, aperture: aperture, shutter_speed: shutter_speed)}
+  end
+
+  def handle_event("toggle_symbol", %{"symbol" => symbol}, socket) do
+    used_symbols =
+      if symbol in socket.assigns.used_symbols do
+        List.delete(socket.assigns.used_symbols, symbol)
+      else
+        [symbol | socket.assigns.used_symbols]
+      end
+
+    {:noreply, assign(socket, used_symbols: used_symbols)}
+  end
+
+  def handle_event("update_notes", %{"value" => notes}, socket) do
+    {:noreply, assign(socket, notes: notes)}
+  end
+
+  defp calculate_exposure(ev, iso) when is_integer(ev) do
+    # For Sunny 16 rule (EV 15)
+    if ev == 15 do
+      {"f/16", "1/#{iso}"}
+    else
+      # Simple exposure calculation based on EV difference from Sunny 16
+      ev_diff = ev - 15
+
+      # Each EV change is 1 stop
+      # Simplified calculation for demonstration
+      if ev_diff > 0 do
+        # Brighter than sunny 16
+        {"f/#{16 * :math.pow(2, div(ev_diff, 2))}",
+         "1/#{iso * :math.pow(2, ev_diff - div(ev_diff, 2))}"}
+      else
+        # Darker than sunny 16
+        {"f/#{16 / :math.pow(2, div(-ev_diff, 2))}",
+         "1/#{iso / :math.pow(2, -ev_diff - div(-ev_diff, 2))}"}
+      end
+      |> format_exposure_values()
+    end
+  end
+
+  defp calculate_exposure(ev, iso) do
+    # For non-integer EV ranges like "17-21"
+    {"Varies", "Varies"}
+  end
+
+  defp format_exposure_values({aperture, shutter_speed}) when is_float(aperture) do
+    aperture_str = "f/#{:io_lib.format("~.1f", [aperture]) |> to_string() |> String.trim()}"
+
+    shutter_speed_str =
+      cond do
+        shutter_speed < 1 -> "1/#{round(1 / shutter_speed)}"
+        true -> "#{:io_lib.format("~.1f", [shutter_speed]) |> to_string() |> String.trim()}"
+      end
+
+    {aperture_str, shutter_speed_str}
+  end
+
+  defp format_exposure_values(values), do: values
+end

--- a/lib/film_flow_web/live/exposure_guide_live/index.html.heex
+++ b/lib/film_flow_web/live/exposure_guide_live/index.html.heex
@@ -1,0 +1,240 @@
+<div class="container mx-auto p-4">
+  <h1 class="text-2xl font-bold mb-4">Photography Exposure Guide</h1>
+
+  <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+    <!-- Left Column -->
+    <div>
+      <div class="bg-gray-100 p-4 rounded-lg mb-6 text-xs">
+        <h3 class="text-base font-bold mb-2">Exposure Values (EV)</h3>
+        <div class="overflow-auto max-h-96">
+          <table class="min-w-full border">
+            <thead>
+              <tr>
+                <th class="border px-4 py-2 bg-gray-200">EV</th>
+                <th class="border px-4 py-2 bg-gray-200">LIGHTING CONDITIONS</th>
+              </tr>
+            </thead>
+            <tbody>
+              <%= for item <- @exposure_values do %>
+                <tr class={
+                  if to_string(item.ev) == to_string(@selected_ev),
+                    do: "bg-blue-200",
+                    else: "hover:bg-gray-50"
+                }>
+                  <td class="border px-4 py-2 text-center">
+                    <button
+                      type="button"
+                      phx-click="select_ev"
+                      phx-value-ev={item.ev}
+                      class="w-full h-full"
+                    >
+                      <%= item.ev %>
+                    </button>
+                  </td>
+                  <td class="border px-4 py-2">
+                    <button
+                      type="button"
+                      phx-click="select_ev"
+                      phx-value-ev={item.ev}
+                      class="w-full h-full text-left"
+                    >
+                      <%= item.condition %>
+                    </button>
+                  </td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="bg-gray-100 p-4 rounded-lg text-xs">
+        <h3 class="text-base font-bold mb-2">Sunny 16 Rule</h3>
+        <p class="mb-2">
+          On a sunny day set aperture to f/16 and shutter speed to the reciprocal of the ISO film speed.
+        </p>
+        <p>
+          Example: Shooting on a sunny day with <%= @iso %> ISO film, set the shutter speed to 1/<%= @iso %>.
+        </p>
+      </div>
+    </div>
+
+    <!-- Middle Column -->
+    <div>
+      <div class="bg-gray-100 p-4 rounded-lg mb-6 text-xs">
+        <h3 class="text-base font-bold mb-2">The Zone System</h3>
+        <div class="overflow-auto max-h-72">
+          <table class="min-w-full border">
+            <thead>
+              <tr>
+                <th class="border px-4 py-2 bg-gray-200 w-1/6">ZONE</th>
+                <th class="border px-4 py-2 bg-gray-200">DESCRIPTION</th>
+              </tr>
+            </thead>
+            <tbody>
+              <%= for zone <- @zone_system do %>
+                <tr class={
+                  if zone.zone == @selected_zone, do: "bg-blue-200", else: "hover:bg-gray-50"
+                }>
+                  <td class="border px-4 py-2 text-center">
+                    <button
+                      type="button"
+                      phx-click="select_zone"
+                      phx-value-zone={zone.zone}
+                      class="w-full h-full"
+                    >
+                      <%= zone.zone %>
+                    </button>
+                  </td>
+                  <td class="border px-4 py-2">
+                    <button
+                      type="button"
+                      phx-click="select_zone"
+                      phx-value-zone={zone.zone}
+                      class="w-full h-full text-left"
+                    >
+                      <%= zone.description %>
+                    </button>
+                  </td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="bg-gray-100 p-4 rounded-lg mb-6 text-xs">
+        <h3 class="text-base font-bold mb-2">Exposure Calculator</h3>
+        <div class="flex flex-col gap-2 mb-4">
+          <div>
+            <label class="block font-medium mb-1">ISO</label>
+            <select class="w-full p-2 border rounded text-xs" phx-change="update_iso">
+              <%= for iso <- [50, 100, 200, 400, 800, 1600, 3200, 6400] do %>
+                <option value={iso} selected={@iso == iso}><%= iso %></option>
+              <% end %>
+            </select>
+          </div>
+          <div>
+            <label class="block font-medium mb-1">Aperture</label>
+            <input
+              type="text"
+              value={@aperture}
+              readonly
+              class="w-full p-2 border rounded bg-gray-50 text-xs"
+            />
+          </div>
+          <div>
+            <label class="block font-medium mb-1">Shutter Speed</label>
+            <input
+              type="text"
+              value={@shutter_speed}
+              readonly
+              class="w-full p-2 border rounded bg-gray-50 text-xs"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Right Column -->
+    <div>
+      <div class="bg-gray-100 p-4 rounded-lg text-xs">
+        <h3 class="text-base font-bold mb-2">Symbol Key</h3>
+        <div class="grid grid-cols-4 gap-1">
+          <%= for symbol <- @symbol_key do %>
+            <button
+              phx-click="toggle_symbol"
+              phx-value-symbol={symbol.symbol}
+              class={"flex flex-col items-center justify-center px-1 py-1 rounded-md text-xs #{if symbol.symbol in @used_symbols, do: "bg-blue-100 text-blue-800", else: "bg-gray-100 text-gray-700 hover:bg-gray-200"}"}
+            >
+              <span class="text-lg mb-0.5"><%= symbol.symbol %></span>
+              <span class="text-[10px] text-center"><%= symbol.meaning %></span>
+            </button>
+          <% end %>
+        </div>
+      </div>
+      <div class="bg-gray-100 p-4 rounded-lg mb-6 text-xs mt-6">
+        <h3 class="text-base font-bold mb-4">Shooting Conditions</h3>
+        <div class="grid grid-cols-2 gap-3">
+          <%= for symbol <- @symbol_key do %>
+            <div class="flex items-center">
+              <input
+                type="checkbox"
+                id={"symbol-#{symbol.symbol}"}
+                phx-click="toggle_symbol"
+                phx-value-symbol={symbol.symbol}
+                checked={symbol.symbol in @used_symbols}
+                class="mr-2"
+              />
+              <label for={"symbol-#{symbol.symbol}"} class="flex items-center cursor-pointer">
+                <span class="text-lg mr-1"><%= symbol.symbol %></span>
+                <span class="text-xs"><%= symbol.meaning %></span>
+              </label>
+            </div>
+          <% end %>
+        </div>
+      </div>
+      <div class="bg-gray-100 p-4 rounded-lg text-xs">
+        <h3 class="text-base font-bold mb-2">Notes</h3>
+        <textarea
+          class="w-full p-2 border rounded"
+          rows="3"
+          phx-change="update_notes"
+          phx-debounce="300"
+        ><%= @notes %></textarea>
+      </div>
+    </div>
+  </div>
+
+  <div class="mt-6 bg-gray-100 p-4 rounded-lg text-xs">
+    <h3 class="text-base font-bold mb-2">Reciprocity Failure</h3>
+    <p>
+      Longer exposure times (and occasionally very short times) require compensation to ensure correct exposure. This varies film to film: consult the data sheet that came with the film, contact the manufacturer, or research online.
+    </p>
+  </div>
+
+  <!-- Metered Exposure / Compensated Exposure Panel -->
+  <div class="mt-6 bg-gray-100 p-4 rounded-lg text-xs">
+    <h3 class="text-base font-bold mb-2">Metered Exposure / Compensated Exposure</h3>
+    <form phx-submit="save_metered_exposure">
+      <div class="font-semibold text-xs mb-1">Metered Exposure</div>
+      <div class="flex mb-2">
+        <div class="w-32"></div>
+        <div class="grid grid-cols-10 gap-0 flex-1">
+          <%= for col <- 0..9 do %>
+            <input type="text" name={"metered_exposure[metered][" <> to_string(col) <> "]"} class="w-full p-1 rounded border text-xs text-center" />
+          <% end %>
+        </div>
+      </div>
+      <div class="font-semibold text-xs mb-1">Film / Compensated Exposure</div>
+      <table class="min-w-full border text-xs mb-2">
+        <thead>
+          <tr>
+            <th class="border px-2 py-1 bg-gray-200 w-32">Film</th>
+            <th class="border px-2 py-1 bg-gray-200" colspan="10">Compensated Exposure</th>
+          </tr>
+        </thead>
+        <tbody>
+          <%= for row <- 0..5 do %>
+            <tr>
+              <td class="border px-2 py-1 w-32">
+                <select name={"metered_exposure[" <> to_string(row) <> "][film_id]"} class="w-full p-1 rounded border text-xs">
+                  <option value="">Select film</option>
+                  <%= for film <- @films do %>
+                    <option value={film.id}><%= film.name %></option>
+                  <% end %>
+                </select>
+              </td>
+              <%= for col <- 0..9 do %>
+                <td class="border px-1 py-1">
+                  <input type="text" name={"metered_exposure[" <> to_string(row) <> "][compensated][" <> to_string(col) <> "]"} class="w-full p-1 rounded border text-xs text-center" />
+                </td>
+              <% end %>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+      <button type="submit" class="bg-blue-600 text-white px-4 py-1 rounded hover:bg-blue-700">Save</button>
+    </form>
+  </div>
+</div> 

--- a/lib/film_flow_web/router.ex
+++ b/lib/film_flow_web/router.ex
@@ -21,15 +21,6 @@ defmodule FilmFlowWeb.Router do
     pipe_through :browser
 
     get "/", PageController, :home
-    # GET     /users           HelloWeb.UserController :index
-    # GET     /users/:id/edit  HelloWeb.UserController :edit
-    # GET     /users/new       HelloWeb.UserController :new
-    # GET     /users/:id       HelloWeb.UserController :show
-    # POST    /users           HelloWeb.UserController :create
-    # PATCH   /users/:id       HelloWeb.UserController :update
-    # PUT     /users/:id       HelloWeb.UserController :update
-    # DELETE  /users/:id       HelloWeb.UserController :delete
-
   end
 
   # Other scopes may use custom stacks.
@@ -77,6 +68,7 @@ defmodule FilmFlowWeb.Router do
       on_mount: [{FilmFlowWeb.UserAuth, :ensure_authenticated}] do
       live "/users/settings", UserSettingsLive, :edit
       live "/users/settings/confirm_email/:token", UserSettingsLive, :confirm_email
+      live "/exposure-guide", ExposureGuideLive.Index, :index
 
       get "/cameras", CameraController, :index
       get "/cameras/:id/edit", CameraController, :edit


### PR DESCRIPTION
This feature introduces an Exposure Guide page that provides photographers with a comprehensive reference for exposure values, the zone system, the Sunny 16 rule, an exposure calculator, a metered and compensated exposure table, a symbol key, shooting conditions, and notes. The page uses a clean three-column layout with consistent styling and includes a film dropdown sourced from the database.
Implemented by AI assistant (OpenAI GPT-4).